### PR TITLE
fix: k8s api

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -238,6 +238,7 @@ const updateTokenSecret = async (
       undefined,
       undefined,
       undefined,
+      undefined,
       opts
     );
     context.log.info('GH Token patched.');


### PR DESCRIPTION
fixes #30 

copy-pasta from https://github.com/emartech/gap-secret-editor/commit/9a5b045f91a3696ac21b3007c011ae3791bac9bc

cc @tumido 

not sure why it doesn't break the deployed app
maybe dependency locking?